### PR TITLE
Allow cross-references to be surrounded by parentheses

### DIFF
--- a/lib/crossrefs.lua
+++ b/lib/crossrefs.lua
@@ -19,8 +19,8 @@ end
 ---@param str Str
 ---@return Inline[] | nil
 M._parse_crossref = function(str)
-   local opening_bracket, prefix_suppressor, id, closing_bracket1, punctuation, closing_bracket2 =
-      str.text:match('^(%[?)(%-?)#([%a%d-_:%.]-)(%]?)([\\%.!:?,;)]-)(%]?)$')
+   local opening_parentheses, opening_bracket, prefix_suppressor, id, closing_bracket1, punctuation, closing_bracket2, closing_parentheses = --luacheck: ignore 631
+      str.text:match('^(%(?)(%[?)(%-?)#([%a%d-_:%.]-)(%]?)([\\%.!:?,;)]-)(%]?)(%)?)$')
    if not id or id == '' then return end
    local only_internal_punctuation = id:find('^[%a%d]+[%a%d%-_:%.]*[%a%d]+$') or id:find('^[%a%d]+$')
    if not only_internal_punctuation then return end
@@ -33,6 +33,8 @@ M._parse_crossref = function(str)
    if closing_bracket1 == ']' then elts:insert(pandoc.Str(']')) end
    if punctuation ~= '' then elts:insert(pandoc.Str(punctuation)) end
    if closing_bracket2 == ']' then elts:insert(pandoc.Str(']')) end
+   if opening_parentheses == '(' then elts:insert(1, pandoc.Str('(')) end
+   if closing_parentheses == ')' then elts:insert(pandoc.Str(')')) end
 
    return elts
 end

--- a/spec/units/crossrefs.lua
+++ b/spec/units/crossrefs.lua
@@ -87,6 +87,15 @@ describe('_parse_crossref', function()
       assert.equal('#fig:equal-heights', inlines[1].target) ---@diagnostic disable-line: need-check-nil
    end)
 
+   it('parses cross-reference in parentheses', function()
+      local inlines = crossrefs._parse_crossref(pandoc.Str('(#fig1)'))
+      assert.is_not_nil(inlines)
+      assert.equal(3, #inlines)
+      assert.equal('Str', inlines[1].tag) ---@diagnostic disable-line: need-check-nil
+      assert.equal('Link', inlines[2].tag) ---@diagnostic disable-line: need-check-nil
+      assert.equal('Str', inlines[3].tag) ---@diagnostic disable-line: need-check-nil
+   end)
+
    it("doesn't parse invalid cross-references", function()
       -- Space in cross-reference
       assert.is_nil(crossrefs._parse_crossref(pandoc.Str('# fig1')))


### PR DESCRIPTION
Close #29.