### PR TITLE
Move `unnumbered` class from Image to containing Figure

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -41,6 +41,9 @@ function Pandoc(doc)
          Inlines = crossrefs.parse_crossrefs,
       })
       :walk({
+         Figure = numbering.move_unnumbered_class,
+      })
+      :walk({
          -- Number cross-referenceable elements and construct table with Ids and numbers.
          traverse = 'topdown', -- needed for subfigs
          Pandoc = numbering.number_sections,

--- a/lib/numbering.lua
+++ b/lib/numbering.lua
@@ -2,6 +2,26 @@ local utils = require('lib.utils')
 
 local M = {}
 
+---Move class `unnumbered` from Image to containing Figure.
+---@param fig Figure
+---@return Figure?
+M.move_unnumbered_class = function(fig)
+   if
+      #fig.content == 1
+      and fig.content[1].tag == 'Plain'
+      and #fig.content[1].content == 1
+      and fig.content[1].content[1].tag == 'Image'
+   then
+      local img = fig.content[1].content[1]
+      ---@cast img Image
+      if img.classes:includes('unnumbered') then
+         img.classes:remove(img.classes:find('unnumbered')[2])
+         fig.classes:insert('unnumbered')
+         return fig
+      end
+   end
+end
+
 local docx_bmk_id = 100000 -- large number to prevent collisions with bookmark Ids used by pandoc.
 
 local function get_docx_bmk_id()

--- a/spec/golden/md2html/expected.html
+++ b/spec/golden/md2html/expected.html
@@ -24,7 +24,12 @@
 </tr>
 </tbody>
 </table>
-<h1 data-number="4" id="groups-of-cross-references"><span class="header-section-number">4</span> Groups of cross-references</h1>
+<h1 data-number="4" id="unnumbered-figure"><span class="header-section-number">4</span> Unnumbered figure</h1>
+<figure class="unnumbered">
+<img src="img.jpg" alt="Figure caption." />
+<figcaption aria-hidden="true">Figure caption.</figcaption>
+</figure>
+<h1 data-number="5" id="groups-of-cross-references"><span class="header-section-number">5</span> Groups of cross-references</h1>
 <figure id="fig2">
 <img src="fig2.jpg" alt="test" />
 <figcaption><span class="figure-label">Fig. 2: </span>test</figcaption>
@@ -38,15 +43,15 @@
 <p>See <span class="cross-ref-group"><span class="crossrefs-of-a-kind">Figs. <a href="#fig1" class="cross-ref">1</a>, <a href="#fig2" class="cross-ref">2</a>, and <a href="#fig3" class="cross-ref">3</a></span></span>.</p>
 <p>See <span class="cross-ref-group"><span class="crossrefs-of-a-kind">Figs. <a href="#fig1" class="cross-ref">1</a>; <a href="#fig2" class="cross-ref">2</a>; <a href="#fig3" class="cross-ref">3</a></span></span>.</p>
 <p>See <span class="cross-ref-group"><span class="crossrefs-of-a-kind">Figs. <a href="#fig1" class="cross-ref">1</a> and <a href="#fig2" class="cross-ref">2</a></span></span>.</p>
-<h1 data-number="5" id="groups-of-cross-references-of-non-uniform-types"><span class="header-section-number">5</span> Groups of cross-references of non-uniform types</h1>
+<h1 data-number="6" id="groups-of-cross-references-of-non-uniform-types"><span class="header-section-number">6</span> Groups of cross-references of non-uniform types</h1>
 <p>See <span class="cross-ref-group"><a href="#sec1" class="cross-ref">Sec. 1</a> and <span class="crossrefs-of-a-kind">Figs. <a href="#fig2" class="cross-ref">2</a> and <a href="#fig3" class="cross-ref">3</a></span></span>.</p>
 <p>See <span class="cross-ref-group"><span class="crossrefs-of-a-kind">Secs. <a href="#sec1" class="cross-ref">1</a> and <a href="#sec2" class="cross-ref">2</a></span> and <a href="#fig3" class="cross-ref">Fig. 3</a></span>.</p>
 <p>See <span class="cross-ref-group"><a href="#eq1" class="cross-ref">Eqn. 1</a>, <a href="#fig2" class="cross-ref">Fig. 2</a>, and <a href="#sec3" class="cross-ref">Sec. 3</a></span>.</p>
 <p>See <span class="cross-ref-group"><a href="#eq1" class="cross-ref">Eqn. 1</a> and <a href="#fig1" class="cross-ref">Fig. 1</a></span>.</p>
 <p>See <span class="cross-ref-group"><a href="#eq1" class="cross-ref">Eqn. 1</a> and <span class="crossrefs-of-a-kind">Figs. <a href="#fig1" class="cross-ref">1</a>, <a href="#fig2" class="cross-ref">2</a>, and <a href="#fig3" class="cross-ref">3</a></span></span>.</p>
-<h1 data-number="6" id="cross-reference-with-suppressed-prefix"><span class="header-section-number">6</span> Cross-reference with suppressed prefix</h1>
+<h1 data-number="7" id="cross-reference-with-suppressed-prefix"><span class="header-section-number">7</span> Cross-reference with suppressed prefix</h1>
 <p>See <a href="#fig1" class="cross-ref">1</a>.</p>
 <p>See <a href="#fig1" class="cross-ref">Figure 1</a>.</p>
-<h1 data-number="7" id="pathological-cases"><span class="header-section-number">7</span> Pathological cases</h1>
+<h1 data-number="8" id="pathological-cases"><span class="header-section-number">8</span> Pathological cases</h1>
 <p>Single cross-reference in group: See <span class="cross-ref-group"><a href="#eq1" class="cross-ref">Eqn. 1</a></span>.</p>
 <p>Cross-reference group that doesn’t begin and end in a cross-reference: See <span class="cross-ref-group">in particular <span class="crossrefs-of-a-kind">Secs. <a href="#sec1" class="cross-ref">1</a>, <a href="#sec2" class="cross-ref">2</a>, and <a href="#sec3" class="cross-ref">3</a></span> as well.</span></p>

--- a/spec/golden/md2html/input.md
+++ b/spec/golden/md2html/input.md
@@ -23,6 +23,11 @@ b         wingspan
 Table: Table caption {#tbl1 .class key=val}
 
 
+# Unnumbered figure
+
+![Figure caption.](img.jpg){.unnumbered}
+
+
 # Groups of cross-references
 
 ![test](fig2.jpg){#fig2}

--- a/spec/units/numbering.lua
+++ b/spec/units/numbering.lua
@@ -15,6 +15,15 @@ local function create_dummy_figure(caption_str)
    return pandoc.Figure(pandoc.Plain(pandoc.Image('alt text', 'test.jpg')), pandoc.Caption(caption_str))
 end
 
+describe('move_unnumbered_class', function()
+   it('moves `unnumbered` class', function()
+      local fig = create_dummy_figure('Caption')
+      fig.content[1].content[1].classes:insert('unnumbered')
+      local modified_fig = numbering.move_unnumbered_class(fig)
+      assert.is_true(modified_fig.classes:includes('unnumbered')) ---@diagnostic disable-line: need-check-nil
+   end)
+end)
+
 describe('number_sections', function()
    _G.IDs = {}
    local header_doc = pandoc.Pandoc {


### PR DESCRIPTION
Otherwise, assigning the `unnumbered` class to a Figure in Markdown has no effect, as the class is assigned to the Image, not the containing Figure. Close #28.